### PR TITLE
Document POST end point configuration and remove http references to Charm

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,34 @@ Usage
 ```html
 <script>
   __CHARM = {
-    post_end_point: '/contact'
+    url: '/contact'
   }
 </script>
 <script src="charmeur.js" defer async></script>
 ```
 
+`url` will be used both for `POST` for you to send your messages, and as well as a GET link the user can reach with right-click/open in new tab or as a bookmark when it's useful.
+
+TODO: provide a better explanation above!
 TODO: document manuel invocation
 TODO: document label customization
 TODO: document CSS customization
+
+How to show the popup at page load
+----------------------------------
+
+```html
+<script>
+  __CHARM = {
+    url: '/contact'
+  }
+</script>
+<!-- note - no defer async here -->
+<script src="charmeur.js"></script>
+<script>
+  __CHARM.show();
+</script>
+```
 
 Alpha warning
 -------------

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Usage
 
 ```html
 <script>
-__CHARM = { }
+  __CHARM = {
+    post_end_point: '/contact'
+  }
 </script>
 <script src="charmeur.js" defer async></script>
 ```
@@ -42,7 +44,6 @@ Because of that, please do send pull requests!
 
 Some things to do:
 
-* More configurable (POST endpoint!)
 * Documentation!
 * Demos
 * Mobile/responsive layout

--- a/charmeur.js
+++ b/charmeur.js
@@ -138,6 +138,7 @@
   function init(){
     tab = document.createElement('a');
     tab.id = "CHARM_TAB";
+    tab.href = __CHARM['url'];
     tab.onclick = function(){ show(); return false };
     document.body.appendChild(tab);
     csstag(STYLE);
@@ -221,9 +222,7 @@
       data('user_agent', navigator.userAgent);
       data('local_time', (new Date).toString());
 
-      if('post_end_point' in __CHARM){
-        $('CHARM_FORM').action = __CHARM['post_end_point'];
-      }
+      $('CHARM_FORM').action = __CHARM['url'];
 
       setTimeout(function(){
         var scrollTop = document.body.scrollTop;

--- a/charmeur.js
+++ b/charmeur.js
@@ -82,7 +82,7 @@
     BOX =
       '<span id="CHARM_TEXT"></span>'+
       '<iframe id="CHARM_FORM_TARGET" name="CHARM_FORM_TARGET" src="javascript:void(0)" onload="__CHARM&&__CHARM.iFrameLoaded&&__CHARM.iFrameLoaded()" onerror="__CHARM&&__CHARM.iFrameError&&__CHARM.iFrameError()"></iframe>'+
-      '<form id="CHARM_FORM" target="CHARM_FORM_TARGET" action="https://secure.charmhq.com/feedback" method="POST">'+
+      '<form id="CHARM_FORM" target="CHARM_FORM_TARGET" method="POST">'+
       '<div id="CHARM_YOUR_EMAIL"></div>'+
       '<div id="CHARM_YOUR_COMMENT"></div>'+
       '<textarea id="CHARM_COMMENT" name="content" class="ignore-return-pressed"></textarea>'+
@@ -138,8 +138,6 @@
   function init(){
     tab = document.createElement('a');
     tab.id = "CHARM_TAB";
-    
-    tab.href = "https://secure.charmhq.com/feedback/" + __CHARM.key;
     tab.onclick = function(){ show(); return false };
     document.body.appendChild(tab);
     csstag(STYLE);
@@ -223,8 +221,8 @@
       data('user_agent', navigator.userAgent);
       data('local_time', (new Date).toString());
 
-      if('charm_url' in __CHARM){
-        $('CHARM_FORM').action = __CHARM['charm_url'];
+      if('post_end_point' in __CHARM){
+        $('CHARM_FORM').action = __CHARM['post_end_point'];
       }
 
       setTimeout(function(){


### PR DESCRIPTION
Work on #1; custom post end point was already supported, I just documented it and changed the configuration name.

Additional useful resources which I did not include yet but that were required to get things working here:
- add support for Rails authenticity_token (368cbcd4c542158276662608da6ff1402e77d48c)
- harcode assets path for Rails 3 (7559bf68158c21894f305c2af7ea94ca3ce997be - until we have a configurable option for this)

I'm unsure about the removal of `tab.href` - I understand it was to redirect to a Charm-hosted page that just shows the popup, but I have no idea if no href can cause issues on a given browser.

Let me know if anything needs some polishing!
